### PR TITLE
fix readme, line length

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,8 @@ The repository structure is shown here:
 
 ### Build Process
 
-To build the source, open a shell where you cloned the repository, change to the *src* directory,
-and launch:
+To build the source, open a shell where you cloned the repository, change to the
+base directory, and launch:
 
 ```
 $ cargo build


### PR DESCRIPTION
This PR fixes at least one README line according to markdownlint de-facto standard markdown linter, plus it fixes building instructions since we no longer have a `src` directory in this codebase. Please enjoy.